### PR TITLE
Error status with body

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ func (c *Foo) Get() interface{} {
 }
 ```
 
+For most client errors which leads to a response with HTTP status code 4xx, you may also return the response with a content body.
+```
+type ErrorMessageModel struct {
+    Msg string `json:"msg"`
+}
+
+func (c *Foo) Get() interface{} {
+    return c.NotFound(&ErrorMessageModel{Msg: "You've entered the wrong URL."})
+}
+```
+
 ## Authentication
 You can provide your customized user and role provider when you implement vitali.UserProvider interface, and then setup the user provider as follows:
 ```

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ type ErrorMessageModel struct {
 }
 
 func (c *Foo) Get() interface{} {
-    return c.NotFound(ErrorMessageModel{Msg: "You've entered the wrong URL."})
+    return c.NotFound(ErrorMessageModel{Msg: "Wrong URL"})
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ type ErrorMessageModel struct {
 }
 
 func (c *Foo) Get() interface{} {
-    return c.NotFound(&ErrorMessageModel{Msg: "You've entered the wrong URL."})
+    return c.NotFound(ErrorMessageModel{Msg: "You've entered the wrong URL."})
 }
 ```
 

--- a/response_types.go
+++ b/response_types.go
@@ -46,36 +46,40 @@ func (c *Ctx) TempRedirect(uri string) tempRedirect {
 
 // 400
 type badRequest struct {
+    body interface{}
     reason string
 }
 
-func (c *Ctx) BadRequest(reason string) badRequest {
-    return badRequest{reason}
+func (c *Ctx) BadRequest(reason string, bodies ...interface{}) badRequest {
+    return badRequest{extractBody(bodies), reason}
 }
 
 // 401
 type unauthorized struct {
+    body interface{}
     wwwAuthHeader string
 }
 
-func (c *Ctx) Unauthorized(wwwAuthHeader string) unauthorized {
-    return unauthorized{wwwAuthHeader}
+func (c *Ctx) Unauthorized(wwwAuthHeader string, bodies ...interface{}) unauthorized {
+    return unauthorized{extractBody(bodies), wwwAuthHeader}
 }
 
 // 403
 type forbidden struct {
+    body interface{}
 }
 
-func (c *Ctx) Forbidden() forbidden {
-    return forbidden{}
+func (c *Ctx) Forbidden(bodies ...interface{}) forbidden {
+    return forbidden{extractBody(bodies)}
 }
 
 // 404
 type notFound struct {
+    body interface{}
 }
 
-func (c *Ctx) NotFound() notFound {
-    return notFound{}
+func (c *Ctx) NotFound(bodies ...interface{}) notFound {
+    return notFound{extractBody(bodies)}
 }
 
 // 405
@@ -98,27 +102,30 @@ func (c *Ctx) NotAcceptable(provided MediaTypes) notAcceptable {
 
 // 415
 type unsupportedMediaType struct {
+    body interface{}
 }
 
-func (c *Ctx) UnsupportedMediaType() unsupportedMediaType {
-    return unsupportedMediaType{}
+func (c *Ctx) UnsupportedMediaType(bodies ...interface{}) unsupportedMediaType {
+    return unsupportedMediaType{extractBody(bodies)}
 }
 
 // 501
 type notImplemented struct {
+    body interface{}
 }
 
-func (c *Ctx) NotImplemented() notImplemented {
-    return notImplemented{}
+func (c *Ctx) NotImplemented(bodies ...interface{}) notImplemented {
+    return notImplemented{extractBody(bodies)}
 }
 
 // 503
 type serviceUnavailable struct {
+    body interface{}
     seconds int
 }
 
-func (c *Ctx) ServiceUnavailable(seconds int) serviceUnavailable {
-    return serviceUnavailable{seconds}
+func (c *Ctx) ServiceUnavailable(seconds int, bodies ...interface{}) serviceUnavailable {
+    return serviceUnavailable{extractBody(bodies), seconds}
 }
 
 // return this if client is disconnected
@@ -142,4 +149,13 @@ func (c *Ctx) InternalError(e error) internalError {
         why: e.Error(),
         code: errorCode(e.Error()),
     }
+}
+
+func extractBody(bodies []interface{}) interface{}{
+    var body interface{}
+    if len(bodies) > 0 {
+        // Only uses first element as body
+        body = bodies[0]
+    }
+    return body
 }

--- a/vitali.go
+++ b/vitali.go
@@ -199,7 +199,7 @@ func (c webApp) matchRules(w *wrappedWriter, r *http.Request) (result interface{
                if !checkPermission(PermTag, Method(r.Method),
                        ctx.Roles) {
                    if user == "" {
-                       result = unauthorized{c.UserProvider.AuthHeader(r)}
+                       result = unauthorized{wwwAuthHeader: c.UserProvider.AuthHeader(r)}
                    } else {
                        result = forbidden{}
                    }


### PR DESCRIPTION
```go
type ErrorMessageModel struct {
    Msg string `json:"msg"`
}

func (c *Foo) Get() interface{} {
    return c.NotFound(ErrorMessageModel{Msg: "Wrong URL"})
}
```

returns

```json
{ "msg": "Wrong URL" }
```

as the body of a response with HTTP status code 404.